### PR TITLE
Prevent attribute missing warnings

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -42,6 +42,7 @@ asciidoc:
     linkattrs: ''
     toc: ~
     page-pagination: ''
+    attribute-missing: skip
 ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/9150

These warnings appear because antora enables them by default. https://github.com/asciidoctor/asciidoctor/issues/3482#issuecomment-554616512

When the value is set to `skip` which assciidoctor has as default (as mentioned here https://discuss.asciidoctor.org/skipping-reference-to-missing-attribute-tp7687p7691.html) the warnings are not shown. 