### PR TITLE
Make sure we all use the same version of Antora

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ Installing the Antora is super simple:
 
 [source]
 ----
-$ npm i -g @antora/cli@3.0.0 @antora/site-generator@3.0.0
+$ npm i -g @antora/cli@3.0.1 @antora/site-generator@3.0.1
 ----
 
 Check out https://docs.antora.org/antora/3.0/install/install-antora/[the detailed installation instructions]

--- a/deploy
+++ b/deploy
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+set -e
+
+antora_version='3.0.1'
+if ! antora --version | grep -Fq $antora_version; then
+  echo "Error: Please use Antora v$antora_version"
+  exit 1
+fi
+
 antora --fetch antora-playbook.yml
 git add docs
 git commit -m 'Update site docs'


### PR DESCRIPTION
I noticed the diff showing a lot of v3.0.0 / v3.0.1 changes when generating the last docs for rubocop-rspec. Maybe we should make sure to always use the same version? Or maybe it doesn't matter?

The `set -e` also makes sure that we don't push an empty commit in case the `antora` command fails.