### PR TITLE
fix missmatched option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ You can build the documentation locally from this repo.
 [source]
 ----
 $ cd docs.rubocop.org
-$ antora --pull antora-playbook.yml
+$ antora --fetch antora-playbook.yml
 ----
 
 TIP: You can preview your changes by opening `docs/index.html` in your favorite browser.
@@ -58,7 +58,7 @@ You can also use the `deploy` script to publish changes in a single step:
 $ ./deploy
 ----
 
-It basically does `antora --pull` and `git push`.
+It basically does `antora --fetch` and `git push`.
 
 NOTE: You'll need commit access to the repository for this to work.
 


### PR DESCRIPTION
I tried this command `antora --pull antora-playbook.yml` didn't work.
`./deploy` says that we should use `--fetch` instead of `--pull`. is this a typo?
https://github.com/rubocop/docs.rubocop.org/blob/0aa0245013644d3606a450c99d950814bcf2529f/deploy#L11