### PR TITLE
Update @docsearch/js from 3.0.0-alpha.50 to 3.3.3

### DIFF
--- a/supplemental-ui/partials/footer-content.hbs
+++ b/supplemental-ui/partials/footer-content.hbs
@@ -2,7 +2,7 @@
   <p>Copyright (C) 2012-2023 <a href="https://batsov.com">Bozhidar Batsov</a> and RuboCop contributors.</p>
   <p>Except where otherwise noted, docs.rubocop.org is licensed under the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a> (CC BY-SA 4.0).</p>
 </footer>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.1.1"></script>
 <script type="text/javascript">
  docsearch({
    container: '#docsearch',

--- a/supplemental-ui/partials/footer-content.hbs
+++ b/supplemental-ui/partials/footer-content.hbs
@@ -2,7 +2,7 @@
   <p>Copyright (C) 2012-2023 <a href="https://batsov.com">Bozhidar Batsov</a> and RuboCop contributors.</p>
   <p>Except where otherwise noted, docs.rubocop.org is licensed under the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a> (CC BY-SA 4.0).</p>
 </footer>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.1.1"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.3.3"></script>
 <script type="text/javascript">
  docsearch({
    container: '#docsearch',

--- a/supplemental-ui/partials/head-meta.hbs
+++ b/supplemental-ui/partials/head-meta.hbs
@@ -1,4 +1,4 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/site-extra.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.1.1">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.3.3">
 <style>:root{--docsearch-primary-color: #bd362f} </style>
 <link rel="icon" href="{{uiRootPath}}/img/favicon.ico" type="image/x-icon">

--- a/supplemental-ui/partials/head-meta.hbs
+++ b/supplemental-ui/partials/head-meta.hbs
@@ -1,4 +1,4 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/site-extra.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.1.1">
 <style>:root{--docsearch-primary-color: #bd362f} </style>
 <link rel="icon" href="{{uiRootPath}}/img/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
algolia/docsearch (@docsearch/js and @docsearch/css in package name) is already general availability.

- https://github.com/algolia/docsearch/blob/v3.1.1/CHANGELOG.md
- https://github.com/algolia/docsearch/compare/v3.0.0-alpha.50...v3.1.1

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>