### PR TITLE
Use rubocop theme color in docsearch v3

### DIFF
--- a/supplemental-ui/partials/head-meta.hbs
+++ b/supplemental-ui/partials/head-meta.hbs
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/site-extra.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha">
+<style>:root{--docsearch-primary-color: #bd362f} </style>
 <link rel="icon" href="{{uiRootPath}}/img/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
The current color in docsearch v3 UI does not looks consistent with other components.

| before | after |
|-|-|
| ![docs-rubocop-docsearch-as-is](https://user-images.githubusercontent.com/10229505/182425986-a0bc444f-0631-41ad-b5e9-85214f04dbcf.png) | ![docs-rubocop-docsearch](https://user-images.githubusercontent.com/10229505/182425787-c00820d3-c55a-4b0f-8556-aed4b78ac80d.png) |

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>