### PR TITLE
Add `rubocop-thread_safety` plugin documentation

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -138,6 +138,10 @@ content:
       branches: master
       tags: []
       start_path: docs
+    - url: https://github.com/rubocop/rubocop-thread_safety
+      branches: ~
+      tags: ["v0.7.0"]
+      start_path: docs
 asciidoc:
   attributes:
     experimental: ""

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -41,6 +41,7 @@
             <a class="navbar-item" href="https://github.com/rubocop/rubocop-rake">RuboCop Rake</a>
             <a class="navbar-item" href="https://github.com/rubocop/rubocop-rspec">RuboCop RSpec</a>
             <a class="navbar-item" href="https://github.com/rubocop/rubocop-rspec_rails">RuboCop RSpec Rails</a>
+            <a class="navbar-item" href="https://github.com/rubocop/rubocop-thread_safety">RuboCop Thread Safety</a>
           </div>
         </div>
         <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
Resolves https://github.com/rubocop/docs.rubocop.org/issues/25

We added `antora.yml` in `v0.7.0`.